### PR TITLE
Another addition to change WIT

### DIFF
--- a/index.js
+++ b/index.js
@@ -375,6 +375,21 @@ async function label(vm, workItem) {
       value: workItem.fields["System.Tags"] + ", " + vm.label,
     });
   }
+  // set the work item type depending on the label
+  if (vm.label == "bug") {
+    vm.env.wit = "Bug";
+    patchDocument.push({
+      op: "replace",
+      path: "/fields/System.WorkItemType",
+      value: vm.env.wit,
+    });
+  } else if (vm.label == "enhancement") {
+    vm.env.wit = "Scenario";
+    patchDocument.push({
+      op: "replace",
+      path: "/fields/System.WorkItemType",
+      value: vm.env.wit,
+    });
 
   if (patchDocument.length > 0) {
     return await updateWorkItem(patchDocument, workItem.id, vm.env);


### PR DESCRIPTION
Just something else to try. Placing this WIT logic in the label function will hopefully make it a little easier to test, and to rectify if an issue is mislabeled. It also uses a different op type for the patch document (replace instead of add, since the work item should already be created).